### PR TITLE
Multilingual textbox compatibility

### DIFF
--- a/assets/simplemde.publish.js
+++ b/assets/simplemde.publish.js
@@ -23,27 +23,54 @@
 			
 			$(element).closest('.field').addClass('field-simplemde');
 			
-			// Calculate min height based on the number of rows
-			var rows = $(element).attr('rows');
-			var minHeight;
+			// Calculate min height based on the number of rows (default textboxes)
+			// or already existing height-class (multilingual textboxes)
 			
-			if (rows <= 1) {
-				minHeight = '2.6';
-			} else if (rows <= 4) {
-				minHeight = '8.9';
-			} else if (rows <= 7) {
-				minHeight = '15';
-			} else if (rows <= 10) {
-				minHeight = '21.3';
-			} else if (rows <= 13) {
-				minHeight = '27.6';
-			} else if (rows <= 16) {
-				minHeight = '33.9';
+			var minHeight;
+			var isMultilingualTextbox = $(element).closest('.field').is('.field-multilingual_textbox');
+			
+			// Multilingual textboxes
+			
+			if (isMultilingualTextbox) {
+				
+				var size = $(element).attr("class").match(/size[\w-]*\b/).toString().substr(5);
+				
+				if (size === 'small') {
+					minHeight = '5';
+				} else if (size === 'medium') {
+					minHeight = '20';
+				} else if (size === 'large') {
+					minHeight = '35';
+				} else if (size === 'huge') {
+					minHeight = '50';
+				}
+				
+			// Default textboxes
+				
 			} else {
-				minHeight = (rows === '0') ? false : ((( Math.round (rows * 206.666666 - 1) ) / 100));
+				
+				var rows = $(element).attr('rows');
+				
+				if (rows <= 1) {
+					minHeight = '2.6';
+				} else if (rows <= 4) {
+					minHeight = '8.9';
+				} else if (rows <= 7) {
+					minHeight = '15';
+				} else if (rows <= 10) {
+					minHeight = '21.3';
+				} else if (rows <= 13) {
+					minHeight = '27.6';
+				} else if (rows <= 16) {
+					minHeight = '33.9';
+				} else {
+					minHeight = (rows === '0') ? false : ((( Math.round (rows * 206.666666 - 1) ) / 100));
+				}
+				
 			}
 			
 			// Append height to editor
+			
 			$(element).siblings('.CodeMirror').css(
 				'min-height', minHeight+'rem'
 			).find('.CodeMirror-scroll').css(

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -13,27 +13,30 @@
 		</author>
 	</authors>
 	<releases>
-	  <release version="0.4.3" date="2017-08-15" min="2.6" max="2.x.x">
+		<release version="0.4.4" date="2017-12-11" min="2.6" max="2.x.x">
+			- Added compatibility with height settings of Multilingual Textbox Field
+		</release>
+		<release version="0.4.3" date="2017-08-15" min="2.6" max="2.x.x">
 			- Restore borked toolbar
-		</release> 
-	  <release version="0.4.2" date="2017-07-05" min="2.6" max="2.x.x">
+		</release>
+		<release version="0.4.2" date="2017-07-05" min="2.6" max="2.x.x">
 			- Ensure compatibility with »Are you sure?«-extension by forcing textarea-sync
-		</release> 
-    <release version="0.4.1" date="2017-07-05" min="2.6" max="2.x.x">
+		</release>
+		<release version="0.4.1" date="2017-07-05" min="2.6" max="2.x.x">
 			- Use »+« as default character for lists
 			- Tab = 4 spaces
-		</release>  
-    <release version="0.4" date="2017-06-13" min="2.6" max="2.x.x">
+		</release>
+		<release version="0.4" date="2017-06-13" min="2.6" max="2.x.x">
 			- Remove Fontawesome external dependency
 			- Update SimpleMDE to v1.11.2
-		</release>    
+		</release>
 		<release version="0.3" date="2016-03-22" min="2.6" max="2.x.x">
 			- Editor height now adapts to the row-settings of the textarea
 			- Use Symphony's default font settings (instead of monospace fonts)
 		</release>
-    <release version="0.2" date="2016-03-10" min="2.6" max="2.x.x">
+		<release version="0.2" date="2016-03-10" min="2.6" max="2.x.x">
 			- Now works with multiple markdown textareas
-			- No more JS Error when there’s no textarea on the page 
+			- No more JS Error when there’s no textarea on the page
 		</release>
 		<release version="0.1.1" date="2016-03-09" min="2.6" max="2.x.x">
 			- Initial height = 1 line
@@ -42,7 +45,7 @@
 			- Initial Release
 		</release>
 	</releases>
-  <media>
-    <item type="image" url="https://cloud.githubusercontent.com/assets/870227/13945847/d98efd0c-f010-11e5-85f5-bcbe38c930fa.png">Publish Area UI</item>
-  </media>
+	<media>
+		<item type="image" url="https://cloud.githubusercontent.com/assets/870227/13945847/d98efd0c-f010-11e5-85f5-bcbe38c930fa.png">Publish Area UI</item>
+	</media>
 </extension>


### PR DESCRIPTION
Added compatibility with the height settings of "Multilingual Text Box".

The extension "Multilingual Text Box" comes with four "height presets" for textboxes: "small", "medium", "large" and "huge". This PR ensures that simplemde respects those height presets and doesn't format all multilingual text boxes with the same default size of 20 rows.